### PR TITLE
Log levels

### DIFF
--- a/addons/log/log.gd
+++ b/addons/log/log.gd
@@ -39,11 +39,6 @@ static func initialize_setting(key: String, default_value: Variant, type: int, h
 	ProjectSettings.set_initial_value(key, default_value)
 	ProjectSettings.add_property_info({name=key, type=type, hint=hint, hint_string=hint_string})
 
-static func get_setting(key: String) -> Variant:
-	if ProjectSettings.has_setting(key):
-		return ProjectSettings.get_setting(key)
-	return
-
 # settings keys and default ####################################
 
 const KEY_PREFIX: String = "log_gd/config"
@@ -60,6 +55,7 @@ const KEY_USE_NEWLINES: String = "%s/use_newlines" % KEY_PREFIX
 const KEY_NEWLINE_MAX_DEPTH: String = "%s/newline_max_depth" % KEY_PREFIX
 const KEY_LOG_LEVEL: String = "%s/log_level" % KEY_PREFIX
 const KEY_WARN_TODO: String = "%s/warn_todo" % KEY_PREFIX
+const KEY_SHOW_LOG_LEVEL_SELECTOR: String = "%s/show_log_level_selector" % KEY_PREFIX
 
 enum Levels {
 		INFO,
@@ -76,6 +72,7 @@ const CONFIG_DEFAULTS := {
 		KEY_NEWLINE_MAX_DEPTH: -1,
 		KEY_LOG_LEVEL: Levels.INFO,
 		KEY_WARN_TODO: true,
+		KEY_SHOW_LOG_LEVEL_SELECTOR: false,
 	}
 
 # settings setup ####################################
@@ -89,6 +86,7 @@ static func setup_settings(opts: Dictionary = {}) -> void:
 	initialize_setting(KEY_NEWLINE_MAX_DEPTH, CONFIG_DEFAULTS[KEY_NEWLINE_MAX_DEPTH], TYPE_INT)
 	initialize_setting(KEY_LOG_LEVEL, CONFIG_DEFAULTS[KEY_LOG_LEVEL], TYPE_INT, PROPERTY_HINT_ENUM, "Info,Warn,Error")
 	initialize_setting(KEY_WARN_TODO, CONFIG_DEFAULTS[KEY_WARN_TODO], TYPE_BOOL)
+	initialize_setting(KEY_SHOW_LOG_LEVEL_SELECTOR, CONFIG_DEFAULTS[KEY_SHOW_LOG_LEVEL_SELECTOR], TYPE_BOOL)
 
 # config setup ####################################
 
@@ -96,9 +94,7 @@ static var config: Dictionary = {}
 static func rebuild_config(opts: Dictionary = {}) -> void:
 	for key: String in CONFIG_DEFAULTS.keys():
 		# Keep config set in code before to_printable() is called for the first time
-		var val: Variant = Log.config.get(key, get_setting(key))
-		if val == null:
-			val = CONFIG_DEFAULTS[key]
+		var val: Variant = Log.config.get(key, ProjectSettings.get_setting(key, CONFIG_DEFAULTS[key]))
 
 		Log.config[key] = val
 

--- a/addons/log/log.gd
+++ b/addons/log/log.gd
@@ -58,6 +58,7 @@ const KEY_WARN_TODO: String = "%s/warn_todo" % KEY_PREFIX
 const KEY_SHOW_LOG_LEVEL_SELECTOR: String = "%s/show_log_level_selector" % KEY_PREFIX
 
 enum Levels {
+		DEBUG,
 		INFO,
 		WARN,
 		ERROR
@@ -84,7 +85,7 @@ static func setup_settings(opts: Dictionary = {}) -> void:
 	initialize_setting(KEY_SKIP_KEYS, CONFIG_DEFAULTS[KEY_SKIP_KEYS], TYPE_PACKED_STRING_ARRAY)
 	initialize_setting(KEY_USE_NEWLINES, CONFIG_DEFAULTS[KEY_USE_NEWLINES], TYPE_BOOL)
 	initialize_setting(KEY_NEWLINE_MAX_DEPTH, CONFIG_DEFAULTS[KEY_NEWLINE_MAX_DEPTH], TYPE_INT)
-	initialize_setting(KEY_LOG_LEVEL, CONFIG_DEFAULTS[KEY_LOG_LEVEL], TYPE_INT, PROPERTY_HINT_ENUM, "Info,Warn,Error")
+	initialize_setting(KEY_LOG_LEVEL, CONFIG_DEFAULTS[KEY_LOG_LEVEL], TYPE_INT, PROPERTY_HINT_ENUM, "DEBUG,INFO,WARN,ERROR")
 	initialize_setting(KEY_WARN_TODO, CONFIG_DEFAULTS[KEY_WARN_TODO], TYPE_BOOL)
 	initialize_setting(KEY_SHOW_LOG_LEVEL_SELECTOR, CONFIG_DEFAULTS[KEY_SHOW_LOG_LEVEL_SELECTOR], TYPE_BOOL)
 
@@ -587,6 +588,16 @@ static func prnnn(msg: Variant, msg2: Variant = "ZZZDEF", msg3: Variant = "ZZZDE
 static func log(msg: Variant, msg2: Variant = "ZZZDEF", msg3: Variant = "ZZZDEF", msg4: Variant = "ZZZDEF", msg5: Variant = "ZZZDEF", msg6: Variant = "ZZZDEF", msg7: Variant = "ZZZDEF") -> void:
 	var msgs: Array = [msg, msg2, msg3, msg4, msg5, msg6, msg7]
 	msgs = msgs.filter(Log.is_not_default)
+	var m: String = Log.to_printable(msgs, {stack=get_stack()})
+	print_rich(m)
+
+## Pretty-print the passed arguments in a single line.
+static func debug(msg: Variant, msg2: Variant = "ZZZDEF", msg3: Variant = "ZZZDEF", msg4: Variant = "ZZZDEF", msg5: Variant = "ZZZDEF", msg6: Variant = "ZZZDEF", msg7: Variant = "ZZZDEF") -> void:
+	if get_log_level() > Log.Levels.DEBUG:
+		return
+	var msgs: Array = [msg, msg2, msg3, msg4, msg5, msg6, msg7]
+	msgs = msgs.filter(Log.is_not_default)
+	msgs.push_front("[DEBUG]")
 	var m: String = Log.to_printable(msgs, {stack=get_stack()})
 	print_rich(m)
 

--- a/addons/log/log.gd
+++ b/addons/log/log.gd
@@ -58,6 +58,13 @@ const KEY_MAX_ARRAY_SIZE: String = "%s/max_array_size" % KEY_PREFIX
 const KEY_SKIP_KEYS: String = "%s/dictionary_skip_keys" % KEY_PREFIX
 const KEY_USE_NEWLINES: String = "%s/use_newlines" % KEY_PREFIX
 const KEY_NEWLINE_MAX_DEPTH: String = "%s/newline_max_depth" % KEY_PREFIX
+const KEY_LOG_LEVEL: String = "%s/log_level" % KEY_PREFIX
+
+enum Levels {
+		INFO,
+		WARN,
+		ERROR
+	}
 
 const CONFIG_DEFAULTS := {
 		KEY_COLOR_THEME_RESOURCE_PATH: "res://addons/log/color_theme_dark.tres",
@@ -66,6 +73,7 @@ const CONFIG_DEFAULTS := {
 		KEY_SKIP_KEYS: ["layer_0/tile_data"],
 		KEY_USE_NEWLINES: false,
 		KEY_NEWLINE_MAX_DEPTH: -1,
+		KEY_LOG_LEVEL: Levels.INFO
 	}
 
 # settings setup ####################################
@@ -77,6 +85,7 @@ static func setup_settings(opts: Dictionary = {}) -> void:
 	initialize_setting(KEY_SKIP_KEYS, CONFIG_DEFAULTS[KEY_SKIP_KEYS], TYPE_PACKED_STRING_ARRAY)
 	initialize_setting(KEY_USE_NEWLINES, CONFIG_DEFAULTS[KEY_USE_NEWLINES], TYPE_BOOL)
 	initialize_setting(KEY_NEWLINE_MAX_DEPTH, CONFIG_DEFAULTS[KEY_NEWLINE_MAX_DEPTH], TYPE_INT)
+	initialize_setting(KEY_LOG_LEVEL, CONFIG_DEFAULTS[KEY_LOG_LEVEL], TYPE_INT, PROPERTY_HINT_ENUM, "Info,Warn,Error")
 
 # config setup ####################################
 
@@ -132,6 +141,9 @@ static func get_use_newlines() -> bool:
 static func get_newline_max_depth() -> int:
 	return Log.config.get(KEY_NEWLINE_MAX_DEPTH, CONFIG_DEFAULTS[KEY_NEWLINE_MAX_DEPTH])
 
+static func get_log_level() -> int:
+	return Log.config.get(KEY_LOG_LEVEL, CONFIG_DEFAULTS[KEY_LOG_LEVEL])
+
 ## config setters ###################################################################
 
 ## Disable color-wrapping output.
@@ -170,6 +182,10 @@ static func set_newline_max_depth(new_depth: int) -> void:
 ## Resets the maximum object depth for newlines to the default.
 static func reset_newline_max_depth() -> void:
 	Log.config[KEY_USE_NEWLINES] = CONFIG_DEFAULTS[KEY_NEWLINE_MAX_DEPTH]
+
+## Set the minimum level of logs that get printed
+static func set_log_level(new_log_level: int) -> void:
+	Log.config[KEY_LOG_LEVEL] = new_log_level
 
 ## set color theme ####################################
 
@@ -566,6 +582,8 @@ static func log(msg: Variant, msg2: Variant = "ZZZDEF", msg3: Variant = "ZZZDEF"
 
 ## Pretty-print the passed arguments in a single line.
 static func info(msg: Variant, msg2: Variant = "ZZZDEF", msg3: Variant = "ZZZDEF", msg4: Variant = "ZZZDEF", msg5: Variant = "ZZZDEF", msg6: Variant = "ZZZDEF", msg7: Variant = "ZZZDEF") -> void:
+	if get_log_level() > Log.Levels.INFO:
+		return
 	var msgs: Array = [msg, msg2, msg3, msg4, msg5, msg6, msg7]
 	msgs = msgs.filter(Log.is_not_default)
 	msgs.push_front("[INFO]")
@@ -574,6 +592,8 @@ static func info(msg: Variant, msg2: Variant = "ZZZDEF", msg3: Variant = "ZZZDEF
 
 ## Like [code]Log.pr()[/code], but also calls push_warning() with the pretty string.
 static func warn(msg: Variant, msg2: Variant = "ZZZDEF", msg3: Variant = "ZZZDEF", msg4: Variant = "ZZZDEF", msg5: Variant = "ZZZDEF", msg6: Variant = "ZZZDEF", msg7: Variant = "ZZZDEF") -> void:
+	if get_log_level() > Log.Levels.WARN:
+		return
 	var msgs: Array = [msg, msg2, msg3, msg4, msg5, msg6, msg7]
 	msgs = msgs.filter(Log.is_not_default)
 	var rich_msgs: Array = msgs.duplicate()

--- a/addons/log/plugin.gd
+++ b/addons/log/plugin.gd
@@ -2,12 +2,39 @@
 extends EditorPlugin
 
 
+var override_log_level_option_button: OptionButton = OptionButton.new()
+
+var icon_info: Texture2D = EditorInterface.get_editor_theme().get_icon("NodeInfo", "EditorIcons")
+var icon_warn: Texture2D = EditorInterface.get_editor_theme().get_icon("NodeWarning", "EditorIcons")
+var icon_err: Texture2D = EditorInterface.get_editor_theme().get_icon("StatusError", "EditorIcons")
+
+
 func _enter_tree() -> void:
+	override_log_level_option_button.visible = ProjectSettings.get_setting("log_gd/config/show_log_level_selector", false)
+	override_log_level_option_button.add_icon_item(icon_info, "INFO")
+	override_log_level_option_button.add_icon_item(icon_warn, "WARN")
+	override_log_level_option_button.add_icon_item(icon_err, "ERR")
+	override_log_level_option_button.select(Log.get_log_level())
+	override_log_level_option_button.item_selected.connect(override_log_level)
+	add_control_to_container(CONTAINER_TOOLBAR, override_log_level_option_button)
+	override_log_level_option_button.get_parent().move_child(override_log_level_option_button, override_log_level_option_button.get_index() - 2)
+
 	Log.setup_settings()
 	Log.rebuild_config()
 	# TODO only run if some log-specific setting has changed
 	ProjectSettings.settings_changed.connect(on_settings_changed)
 
 
+func _exit_tree() -> void:
+	remove_control_from_container(CONTAINER_TOOLBAR, override_log_level_option_button)
+
+
 func on_settings_changed() -> void:
+	override_log_level_option_button.select(ProjectSettings.get_setting("log_gd/config/log_level"))
+	override_log_level_option_button.visible = ProjectSettings.get_setting("log_gd/config/show_log_level_selector")
 	Log.rebuild_config()
+
+
+func override_log_level(value: Log.Levels) -> void:
+	Log.set_log_level(value)
+	ProjectSettings.set_setting("log_gd/config/log_level", value)

--- a/addons/log/plugin.gd
+++ b/addons/log/plugin.gd
@@ -1,7 +1,6 @@
 @tool
 extends EditorPlugin
 
-var reload_scene_btn: Button = Button.new()
 
 func _enter_tree() -> void:
 	Log.setup_settings()
@@ -9,24 +8,6 @@ func _enter_tree() -> void:
 	# TODO only run if some log-specific setting has changed
 	ProjectSettings.settings_changed.connect(on_settings_changed)
 
-	# TODO does not belong in log.gd... maybe needs a small scale dev-editor addon to house this
-	reload_scene_btn.pressed.connect(reload_scene)
-	reload_scene_btn.text = "Reload"
-	add_control_to_container(CONTAINER_TOOLBAR, reload_scene_btn)
-	reload_scene_btn.get_parent().move_child(reload_scene_btn, reload_scene_btn.get_index() - 2)
-
 
 func on_settings_changed() -> void:
 	Log.rebuild_config()
-
-
-func _exit_tree() -> void:
-	remove_control_from_container(CONTAINER_TOOLBAR, reload_scene_btn)
-
-func reload_scene() -> void:
-	print("-------------------------------------------------")
-	Log.info("[ReloadScene] ", Time.get_time_string_from_system())
-	var edited_scene := EditorInterface.get_edited_scene_root()
-	Log.info("edited scene", edited_scene, ".scene_file_path", edited_scene.scene_file_path)
-	EditorInterface.reload_scene_from_path(edited_scene.scene_file_path)
-	print("-------------------------------------------------")

--- a/addons/log/plugin.gd
+++ b/addons/log/plugin.gd
@@ -4,6 +4,7 @@ extends EditorPlugin
 
 var override_log_level_option_button: OptionButton = OptionButton.new()
 
+var icon_debug: Texture2D = EditorInterface.get_editor_theme().get_icon("Debug", "EditorIcons")
 var icon_info: Texture2D = EditorInterface.get_editor_theme().get_icon("NodeInfo", "EditorIcons")
 var icon_warn: Texture2D = EditorInterface.get_editor_theme().get_icon("NodeWarning", "EditorIcons")
 var icon_err: Texture2D = EditorInterface.get_editor_theme().get_icon("StatusError", "EditorIcons")
@@ -11,9 +12,10 @@ var icon_err: Texture2D = EditorInterface.get_editor_theme().get_icon("StatusErr
 
 func _enter_tree() -> void:
 	override_log_level_option_button.visible = ProjectSettings.get_setting("log_gd/config/show_log_level_selector", false)
+	override_log_level_option_button.add_icon_item(icon_debug, "DEBUG")
 	override_log_level_option_button.add_icon_item(icon_info, "INFO")
 	override_log_level_option_button.add_icon_item(icon_warn, "WARN")
-	override_log_level_option_button.add_icon_item(icon_err, "ERR")
+	override_log_level_option_button.add_icon_item(icon_err, "ERROR")
 	override_log_level_option_button.select(Log.get_log_level())
 	override_log_level_option_button.item_selected.connect(override_log_level)
 	add_control_to_container(CONTAINER_TOOLBAR, override_log_level_option_button)

--- a/addons/reload_current_scene/plugin.cfg
+++ b/addons/reload_current_scene/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="Reload Current Scene"
+description="Helper button to reload the current scene."
+author="Russell Matney"
+version="v0.1.0"
+script="plugin.gd"

--- a/addons/reload_current_scene/plugin.gd
+++ b/addons/reload_current_scene/plugin.gd
@@ -1,0 +1,25 @@
+@tool
+extends EditorPlugin
+
+
+var reload_scene_btn: Button = Button.new()
+
+
+func _enter_tree() -> void:
+	reload_scene_btn.pressed.connect(reload_scene)
+	reload_scene_btn.text = "Reload Scene"
+	reload_scene_btn.icon = EditorInterface.get_editor_theme().get_icon("Reload", "EditorIcons")
+	add_control_to_container(CONTAINER_TOOLBAR, reload_scene_btn)
+	reload_scene_btn.get_parent().move_child(reload_scene_btn, reload_scene_btn.get_index() - 2)
+
+
+func _exit_tree() -> void:
+	remove_control_from_container(CONTAINER_TOOLBAR, reload_scene_btn)
+
+
+func reload_scene() -> void:
+	Log.info("[ReloadScene] Reload initialized", Time.get_time_string_from_system())
+	var edited_scene: Node = EditorInterface.get_edited_scene_root()
+	Log.info("[ReloadScene] Edited scene", "%s.scene_file_path" % edited_scene, edited_scene.scene_file_path)
+	EditorInterface.reload_scene_from_path(edited_scene.scene_file_path)
+	Log.info("[ReloadScene] Scene reloaded", Time.get_time_string_from_system())

--- a/addons/reload_current_scene/plugin.gd.uid
+++ b/addons/reload_current_scene/plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://df3sf44c3b64a

--- a/docs/asset_page_content.md
+++ b/docs/asset_page_content.md
@@ -83,12 +83,23 @@ Log.register_type_overwrite(some_obj.get_class(),
 
 See the [type handlers functions](/?id=type-handlers).
 
-### Color Themes
+### Bring Your Own Color Theme!
 
-There is very rough color theme support. I'd like to develop this further, and
-possibly align it more strongly with Godot's editor color themes.
+As of `v0.0.9` you can create your own `LogColorTheme` and set it via the
+`Project > Settings > Log.gd`.
 
-For now it's a bit hard-coded...
+Log ships with an initial dark and light theme - feel free to duplicate and
+customize as you would. I'd love to provide more themes out of the box, feel
+free to share them via PR or otherwise.
+
+### Log Levels!
+
+Log.gd supports three log levels, `INFO`, `WARN`, and `ERR`.  These levels have
+matching logger functions for ease of use: `Log.info()`, `Log.warn()`, and
+`Log.err()`.  For convenience, `Log.error()` is available.
+
+`Log.todo()` is treated as a `WARN`-level log by default, but can be changed to
+an `INFO`-level log in Project Settings or via `Log.disable_warn_todo()`.
 
 ## Public API
 
@@ -98,12 +109,15 @@ For now it's a bit hard-coded...
   - pretty-print without newlines
 - `Log.prn(...)`, `Log.prnn(...)`, `Log.prnnn(...)`
   - pretty-print with limited newlines
-- `Log.warn(...)`, `Log.todo(...)`
+- `Log.warn(...)`
   - pretty-print without newlines
   - push a warning via `push_warning`
 - `Log.err(...)`, `Log.error(...)`
   - pretty-print without newlines
   - push a error via `push_error`
+- `Log.todo(...)`
+  - pretty-print without newlines
+  - optionally push a warning via `push_warning`
 
 These functions all take up to 7 args.
 We could support more, but you can also pass an Array or a Dictionary if you
@@ -132,6 +146,9 @@ A few functions I use to tweak things at run time (e.g. when running tests).
 - `Log.disable_newlines()`
 - `Log.set_newline_max_depth(new_depth: int)`
 - `Log.reset_newline_max_depth()`
+- `Log.set_log_level()`
+- `Log.disable_warn_todo()`
+- `Log.enable_warn_todo()`
 
 ### Type Handlers
 
@@ -166,6 +183,11 @@ Settings instead of Project-wide ones. I'll be moving things around soon!
 - `newline_max_depth` (`-1`)
   - Limits the object depth where newlines are printed.  Negative values don't
   limit object depth.
+- `log_level` (`Info`)
+  - Sets the project-wide, minimum level to log.
+- `warn_todo` (`true`)
+  - Setting true causes `Log.todo()` to be treated as a `WARN`-level log, false
+  and it gets treated as an `INFO`-level log.
 
 
 ## Contributors

--- a/docs/homepage.md
+++ b/docs/homepage.md
@@ -146,6 +146,16 @@ Log ships with an initial dark and light theme - feel free to duplicate and
 customize as you would. I'd love to provide more themes out of the box, feel
 free to share them via PR or otherwise.
 
+### Log Levels!
+
+Log.gd supports three log levels, `INFO`, `WARN`, and `ERR`.  These levels have
+matching logger functions for ease of use: `Log.info()`, `Log.warn()`, and
+`Log.err()`.  For convenience, `Log.error()` is available.
+
+`Log.todo()` is treated as a `WARN`-level log by default, but can be changed to
+an `INFO`-level log in Project Settings or via `Log.disable_warn_todo()`.
+
+
 ## Public API
 
 ### Print functions
@@ -154,12 +164,15 @@ free to share them via PR or otherwise.
   - pretty-print without newlines
 - `Log.prn(...)`, `Log.prnn(...)`, `Log.prnnn(...)`
   - pretty-print with limited newlines
-- `Log.warn(...)`, `Log.todo(...)`
+- `Log.warn(...)`
   - pretty-print without newlines
   - push a warning via `push_warning`
 - `Log.err(...)`, `Log.error(...)`
   - pretty-print without newlines
   - push a error via `push_error`
+- `Log.todo(...)`
+  - pretty-print without newlines
+  - optionally push a warning via `push_warning`
 
 ?> These functions all take up to 7 args.
 We could support more, but you can also pass an Array or a Dictionary if you
@@ -188,6 +201,9 @@ A few functions I use to tweak things at run time (e.g. when running tests).
 - `Log.disable_newlines()`
 - `Log.set_newline_max_depth(new_depth: int)`
 - `Log.reset_newline_max_depth()`
+- `Log.set_log_level()`
+- `Log.disable_warn_todo()`
+- `Log.enable_warn_todo()`
 
 ### Type Handlers
 
@@ -219,6 +235,11 @@ There are a few Log.gd options available in Project Settings.
 - `newline_max_depth` (`-1`)
   - Limits the object depth where newlines are printed.  Negative values don't
   limit object depth.
+- `log_level` (`Info`)
+  - Sets the project-wide, minimum level to log.
+- `warn_todo` (`true`)
+  - Setting true causes `Log.todo()` to be treated as a warn-level log, false
+  and it gets treated as an info-level log.
 
 ## Other Godot Loggers
 

--- a/project.godot
+++ b/project.godot
@@ -25,7 +25,7 @@ gdscript/warnings/unsafe_call_argument=1
 
 [editor_plugins]
 
-enabled=PackedStringArray("res://addons/gdUnit4/plugin.cfg", "res://addons/log/plugin.cfg")
+enabled=PackedStringArray("res://addons/gdUnit4/plugin.cfg", "res://addons/log/plugin.cfg", "res://addons/reload_current_scene/plugin.cfg")
 
 [gdunit4]
 

--- a/src/ExampleScene.gd
+++ b/src/ExampleScene.gd
@@ -10,6 +10,8 @@ func _enter_tree() -> void:
 	#Log.disable_newlines()
 	#Log.enable_newlines()
 
+	#Log.set_log_level(Log.Levels.WARN)
+
 	#print(Log.config)
 	Log.info(Log.config)
 
@@ -78,12 +80,12 @@ func showcase_easy_newlines() -> void:
 
 func showcase_levels() -> void:
 	print_header("Levels")
-	Log.log(example_object)
-	Log.info(example_object)
-	Log.warn(example_object)
-	Log.todo(example_object)
-	Log.err(example_object)
-	Log.error(example_object)
+	Log.log("Log.log()")
+	Log.info("Log.info()")
+	Log.warn("Log.warn()")
+	Log.todo("Log.todo()")
+	Log.err("Log.err()")
+	Log.error("Log.error()")
 
 func showcase_colors() -> void:
 	print_header("Custom Colors")

--- a/src/ExampleScene.gd
+++ b/src/ExampleScene.gd
@@ -83,6 +83,7 @@ func showcase_easy_newlines() -> void:
 func showcase_levels() -> void:
 	print_header("Levels")
 	Log.log("Log.log()")
+	Log.debug("Log.debug()")
 	Log.info("Log.info()")
 	Log.warn("Log.warn()")
 	Log.todo("Log.todo()")

--- a/src/ExampleScene.gd
+++ b/src/ExampleScene.gd
@@ -12,6 +12,8 @@ func _enter_tree() -> void:
 
 	#Log.set_log_level(Log.Levels.WARN)
 
+	#Log.disable_warn_todo()
+
 	#print(Log.config)
 	Log.info(Log.config)
 


### PR DESCRIPTION
## Synopsis

These changes allow for setting the expected log level for a project and reducing logger noise as a result.

## Context

In [discussion](https://github.com/russmatney/log.gd/pull/8#issuecomment-3233423233) on PR #8 I expressed a want for definable log levels and Russ was amenable to that idea.


## Changes

`Log.debug()` has been added.

`Log.debug()`, `Log.info()`, `Log.warn()`, and `Log.todo()` will only log according to the current log level.

A toggleable log level selector has been added to the toolbar in the editor.

The following config values have been added to adjust the log level and todo warning.  `log_level` defaults to `INFO`, `warn_todo` defaults to `true`, and `show_log_level_selector` defaults to `false`.

```gdscript
log_gd/config/log_level
log_gd/config/warn_todo
log_gd/config/show_log_level_selector
```

The following methods have been added to change the use of log levels in code.

```gdscript
Log.set_log_level()
Log.disable_warn_todo()
Log.enable_warn_todo()
```

Documentation has been updated to reflect the addition of `log_level` and `warn_todo` and their associated code.

No additional tests have been added.


## Other Changes

The reload scene button has been factored out into a standalone plugin.


## Author's Notes

The commits should be fairly self-contained for ease of review.

Optionally warning on `Log.todo()` made sense from a "log it now, warn later in the project" perspective.  Possibly have those TODOs warn during CI or something 🤷🏻‍♀️  Who knows?
