### PR TITLE
Cleaning up and documenting `ExampleScene.gd`, plus a neat lil' GUI

### DIFF
--- a/addons/log/log.gd
+++ b/addons/log/log.gd
@@ -663,6 +663,9 @@ static func error(msg: Variant, msg2: Variant = "ZZZDEF", msg3: Variant = "ZZZDE
 	var m: String = Log.to_printable(msgs, {stack=get_stack(), disable_colors=true})
 	push_error(m)
 
+static func blank() -> void:
+	print()
+
 
 ## Helper that will both print() and print_rich() the enriched string
 static func _internal_debug(msg: Variant, msg2: Variant = "ZZZDEF", msg3: Variant = "ZZZDEF", msg4: Variant = "ZZZDEF", msg5: Variant = "ZZZDEF", msg6: Variant = "ZZZDEF", msg7: Variant = "ZZZDEF") -> void:

--- a/project.godot
+++ b/project.godot
@@ -23,6 +23,12 @@ gdscript/warnings/unsafe_property_access=1
 gdscript/warnings/unsafe_method_access=1
 gdscript/warnings/unsafe_call_argument=1
 
+[display]
+
+window/size/viewport_width=1280
+window/size/viewport_height=720
+window/stretch/mode="canvas_items"
+
 [editor_plugins]
 
 enabled=PackedStringArray("res://addons/gdUnit4/plugin.cfg", "res://addons/log/plugin.cfg", "res://addons/reload_current_scene/plugin.cfg")

--- a/src/ExampleScene.gd
+++ b/src/ExampleScene.gd
@@ -3,6 +3,9 @@ class_name ExampleScene
 extends CanvasLayer
 
 
+## Color used in the custom color showcase
+@export var custom_color: Color = Color.PURPLE
+
 ## An exported array of a custom resource
 @export var some_custom_types: Array[SomeResource] = []
 
@@ -25,6 +28,7 @@ var example_object: ExampleObj = ExampleObj.new({
 
 
 @onready var check_button_colors: CheckButton = %CheckButtonColors
+@onready var color_picker_button: ColorPickerButton = %ColorPickerButton
 @onready var check_button_pretty_colors: CheckButton = %CheckButtonPrettyColors
 @onready var check_button_newlines: CheckButton = %CheckButtonNewlines
 @onready var spin_box_newline_max_depth: SpinBox = %SpinBoxNewlineMaxDepth
@@ -34,6 +38,7 @@ var example_object: ExampleObj = ExampleObj.new({
 
 func _ready() -> void:
 	check_button_colors.set_pressed_no_signal(not Log.get_disable_colors())
+	color_picker_button.color = custom_color
 	check_button_pretty_colors.set_pressed_no_signal(true)
 	check_button_newlines.set_pressed_no_signal(Log.get_use_newlines())
 	spin_box_newline_max_depth.set_value_no_signal(Log.get_newline_max_depth())
@@ -49,6 +54,11 @@ func set_enable_colors(enable: bool) -> void:
 	else:
 		Log.disable_colors()
 		Log.log("Disabled colors")
+
+
+## Connected to ColorPickerButton.
+func set_custom_color(color: Color) -> void:
+	custom_color = color
 
 
 ## Connected to CheckButtonPrettyColors.
@@ -148,10 +158,10 @@ func showcase_colors() -> void:
 	print("Plain ol' print()")
 	print_rich(Log.to_pretty(
 			"Log.gd standard colors with [code]Log.to_pretty()[/code]",
-			{"color": "purple"}))
+			{"color": custom_color}))
 	print_rich(Log.to_pretty(
 			"Custom colors with [code]Log.to_pretty()[/code]",
-			{"color": "purple"}))
+			{"color": custom_color}))
 	print_rich(
 			Log.to_pretty("Disable colors with [code]Log.to_pretty()[/code]",
 			{"disable_colors": true}))

--- a/src/ExampleScene.gd
+++ b/src/ExampleScene.gd
@@ -1,86 +1,136 @@
 @tool
+class_name ExampleScene
 extends CanvasLayer
 
-func _enter_tree() -> void:
-	#print("\\033[31mHello\\033[0m")
 
-	Log.set_colors_pretty()
-	#Log.disable_colors()
+## An exported array of a custom resource
+@export var some_custom_types: Array[SomeResource] = []
 
-	#Log.disable_newlines()
-	#Log.enable_newlines()
-
-	#Log.set_log_level(Log.Levels.WARN)
-
-	#Log.disable_warn_todo()
-
-	#print(Log.config)
-	Log.info(Log.config)
-
-class ExampleObj:
-	var val: Variant
-	func _init(v: Variant) -> void:
-		val = v
-
-	func to_pretty() -> Variant:
-		return {val=val, id=get_instance_id()}
-
+## A complex, deeply nested object
 var example_object: ExampleObj = ExampleObj.new({
-	nested_array={meta="data", nums=[1, 2.4, Vector2i(2, 4)]},
-	nested_dict={two="three", four={five="five", six="six"}},
-	supporting_vectors=[&"StringNames"],
-	and_node_paths=NodePath("SomeNode"),
-	})
+	"nested_array": {
+		"meta": "data",
+		"nums": [1, 2.4, Vector2i(2, 4)]
+	},
+	"nested_dict": {
+		"two": "three",
+		"four": {
+			"five": "five",
+			"six": "six",
+		},
+	},
+	"supporting_vectors": [&"StringNames"],
+	"and_node_paths": NodePath("SomeNode"),
+})
 
-var showcases: Array[Callable] = [
-	showcase_easy_newlines,
-	showcase_levels,
-	showcase_colors,
-	showcase_ints_and_floats,
-	showcase_vectors,
-	showcase_strings,
-	showcase_arrays,
-	showcase_dictionaries,
-	showcase_objects,
-	showcase_known_bugs,
-]
-var showcase_count: int = showcases.size()
-var current_showcase: int = 0
 
-@export var some_custom_types : Array[SomeResource]
+@onready var check_button_colors: CheckButton = %CheckButtonColors
+@onready var check_button_pretty_colors: CheckButton = %CheckButtonPrettyColors
+@onready var check_button_newlines: CheckButton = %CheckButtonNewlines
+@onready var spin_box_newline_max_depth: SpinBox = %SpinBoxNewlineMaxDepth
+@onready var option_button_log_level: OptionButton = %OptionButtonLogLevel
+@onready var check_button_warn_todo: CheckButton = %CheckButtonWarnTodo
+
 
 func _ready() -> void:
-	Log.pr("Hi there!")
-	Log._internal_debug("Hi there!")
+	check_button_colors.set_pressed_no_signal(not Log.get_disable_colors())
+	check_button_pretty_colors.set_pressed_no_signal(true)
+	check_button_newlines.set_pressed_no_signal(Log.get_use_newlines())
+	spin_box_newline_max_depth.set_value_no_signal(Log.get_newline_max_depth())
+	option_button_log_level.select(Log.get_log_level())
+	check_button_warn_todo.set_pressed_no_signal(Log.get_warn_todo())
 
-	#print("\\033[31;1;4mHello\\033[0m")
 
-	# The default for network/limits/debugger/max_chars_per_second is too few
-	# characters for some of the busier showcases to run all at once.  A few
-	# awaits have been delicately sprinkled through to not flood the debugger.
-	await get_tree().create_timer(1.0).timeout
-	await run_showcase()
+## Connected to CheckButtonColors.
+func set_enable_colors(enable: bool) -> void:
+	if enable:
+		Log.enable_colors()
+		Log.log("Enabled colors")
+	else:
+		Log.disable_colors()
+		Log.log("Disabled colors")
 
+
+## Connected to CheckButtonPrettyColors.
+func set_pretty_colors(enable: bool) -> void:
+	if enable:
+		Log.set_colors_pretty()
+		Log.log("Pretty colors enabled")
+	else:
+		Log.set_colors_termsafe()
+		Log.log("Term safe colors enabled")
+
+
+## Connected to CheckButtonNewlines.
+func set_enable_newlines(enable: bool) -> void:
+	if enable:
+		Log.enable_newlines()
+		Log.log("Enabled newlines")
+	else:
+		Log.disable_newlines()
+		Log.log("Disabled newlines")
+
+
+## Connected to SpinBoxNewlineMaxDepth.
+func set_newline_max_depth(depth: float) -> void:
+	Log.set_newline_max_depth(int(depth))
+	Log.log("Newline max depth: %d" % depth)
+
+
+## Connected to OptionButtonLogLevel.
+func set_log_level(log_level: int) -> void:
+	var log_level_lookup: Array[String] = ["Debug", "Info", "Warn", "Error"]
+	Log.set_log_level(log_level)
+	Log.log("Log Level: %s" % log_level_lookup[log_level])
+
+
+## Connected to CheckButtonWarnTodo.
+func set_warn_todo(enable: bool) -> void:
+	if enable:
+		Log.enable_warn_todo()
+		Log.log("Enabled warn todo")
+	else:
+		Log.disable_warn_todo()
+		Log.log("Disabled warn todo")
+
+
+## Easily run all Log.gd showcases.
+func run_showcases() -> void:
+	showcase_easy_newlines()
+	showcase_log_levels()
+	showcase_colors()
+	showcase_ints_and_floats()
+	showcase_vectors()
+	showcase_strings()
+	showcase_arrays()
+	showcase_dictionaries()
+	showcase_objects()
+	showcase_known_bugs()
+
+
+## A simple multi-line header to break up walls of text.
 func print_header(header: String) -> void:
-	print(str("\n\n\t==== ", header, " ====\n"))
+	print_rich(str("\n\n\t==== ", header, " ====\n"))
 
-func run_showcase() -> void:
-	print_header("SHOWCASE")
-	for showcase: Callable in showcases:
-		await showcase.call()
-		await get_tree().create_timer(0.1).timeout
 
+## Showcase [code]Log.pr()[/code], [code]Log.prn()[/code],
+## [code]Log.prnn()[/code], and [code]Log.prnnn()[/code].
 func showcase_easy_newlines() -> void:
-	print_header("Easy Newlines")
+	print_header("Easy Newlines with [code]Log.prn()[/code]")
 	Log.pr(example_object)
-	await get_tree().create_timer(0.34).timeout
+	Log.blank()
+
 	Log.prn(example_object)
-	await get_tree().create_timer(0.34).timeout
+	Log.blank()
+
 	Log.prnn(example_object)
-	await get_tree().create_timer(0.34).timeout
+	Log.blank()
+
 	Log.prnnn(example_object)
 
-func showcase_levels() -> void:
+
+## Showcase all available log levels.
+func showcase_log_levels() -> void:
 	print_header("Levels")
 	Log.log("Log.log()")
 	Log.debug("Log.debug()")
@@ -90,87 +140,168 @@ func showcase_levels() -> void:
 	Log.err("Log.err()")
 	Log.error("Log.error()")
 
+
+## Showcase the custom color functionality of [code]Log.to_pretty()[/code].
 func showcase_colors() -> void:
-	print_header("Custom Colors")
-	Log.pr("custom colors")
-	print_rich(Log.to_pretty(1))
-	print_rich(Log.to_pretty(1, {color_scheme={TYPE_INT: "purple"}}))
+	print_header("Custom Colors with [code]Log.to_pretty()[/code]")
 
-	Log.pr("disabled colors")
-	print_rich(Log.to_pretty(1, {disable_colors=true}))
+	print("Plain ol' print()")
+	print_rich(Log.to_pretty(
+			"Log.gd standard colors with [code]Log.to_pretty()[/code]",
+			{"color": "purple"}))
+	print_rich(Log.to_pretty(
+			"Custom colors with [code]Log.to_pretty()[/code]",
+			{"color": "purple"}))
+	print_rich(
+			Log.to_pretty("Disable colors with [code]Log.to_pretty()[/code]",
+			{"disable_colors": true}))
 
+
+## Showcase ints and floats
 func showcase_ints_and_floats() -> void:
 	print_header("Ints and Floats")
+
 	print(42, 3.14)
-	Log.pr(42, 3.14)
+	Log.log(42, 3.14)
+	Log.blank()
 
 	print(1)
-	Log.pr(1)
+	Log.log(1)
+	Log.blank()
 
 	print(1.0)
-	Log.pr(1.0)
+	Log.log(1.0)
 
+
+## Showcase the printing of Vectors, float and int
 func showcase_vectors() -> void:
 	print_header("Vectors")
+
 	print(Vector2())
-	Log.pr(Vector2())
+	Log.log(Vector2())
+	Log.blank()
 
 	print(Vector3(2.3, 1.4, 0.5))
-	Log.pr(Vector3(2.3, 1.4, 0.5))
+	Log.log(Vector3(2.3, 1.4, 0.5))
+	Log.blank()
 
 	print(Vector2i.LEFT)
-	Log.pr(Vector2i.LEFT)
+	Log.log(Vector2i.LEFT)
+	Log.blank()
 
 	print(Vector3i.UP)
-	Log.pr(Vector3i.UP)
+	Log.log(Vector3i.UP)
 
+
+## Showcase strings and string names
 func showcase_strings() -> void:
 	print_header("Strings and String Names")
-	Log.pr("Hello", &"World")
-	print("Hello, World!")
-	Log.pr("Hello, World!")
-	print(&"Hi there!")
-	Log.pr(&"Hi there!")
 
+	print("Hello, World!")
+	Log.log("Hello, World!")
+	Log.blank()
+
+	print("Hello", &"World")
+	Log.log("Hello", &"World")
+	Log.blank()
+
+	print(&"Hi there!")
+	Log.log(&"Hi there!")
+
+
+## Showcase mixed arrays of various nesting levels
 func showcase_arrays() -> void:
 	print_header("Arrays")
-	print([1, 2.0, 3, 4.0])
-	Log.pr([1, 2.0, 3, 4.0])
-	Log.pr(1, 2.0, [3, 4.0])
-	Log.prn([1, 2.0, 3, 4.0])
 
-	Log.pr("an array of vectors", [
+	var simple_array: Array = [1, 2.0, 3, 4.0]
+	print(simple_array)
+	Log.log(simple_array)
+	Log.prn(simple_array)
+	Log.blank()
+
+	# Until Godot allows unpacking of arrays, I'm not exactly sure how to move
+	# this print statement into a variable effectively.
+	print(1, 2.0, [3, 4.0])
+	Log.log(1, 2.0, [3, 4.0])
+	Log.prn(1, 2.0, [3, 4.0])
+	Log.blank()
+
+	var nested_array: Array = [1, 2.0, [3, 4.0]]
+	print(nested_array)
+	Log.log(nested_array)
+	Log.prn(nested_array)
+	Log.blank()
+
+	var array_with_vectors: Array = [
 		1, 2.0, Vector2(3, 4), Vector3i(1, 3, 0), Vector4(1.1, 2.2, 3.4, 4000)
-		])
+	]
+	print(array_with_vectors)
+	Log.log(array_with_vectors)
+	Log.prn(array_with_vectors)
 
+
+## Showcase dictionaries of various nesting levels
 func showcase_dictionaries() -> void:
 	print_header("Dictionaries")
-	var test_dictionary: Dictionary[String, Variant] = {name="Arthur", quest="I seek the grail", health=0.7}
+	var test_dictionary: Dictionary[String, Variant] = {
+		"name": "Arthur",
+		"quest": "I seek the grail",
+		"health": 0.7,
+	}
 	print(test_dictionary)
-	Log.pr(test_dictionary)
+	Log.log(test_dictionary)
 	Log.prn(test_dictionary)
+	Log.blank()
 
+	var nested_dictionary: Dictionary[String, Variant] = {
+		"name": "Arthur",
+		"quest": "I seek the grail",
+		"health": 0.7,
+		"inventory": {
+			"slot_a": "crown",
+			"slot_b": "sword",
+		},
+	}
+	print(nested_dictionary)
+	Log.log(nested_dictionary)
+	Log.prn(nested_dictionary)
+
+
+## Showcase a handful of different objects.
 func showcase_objects() -> void:
 	print_header("Objects")
 	print(self)
-	Log.pr(self)
+	Log.log(self)
+	Log.blank()
 
-	Log.prn("custom types", some_custom_types)
+	print("custom types", some_custom_types)
+	Log.log("custom types", some_custom_types)
+	Log.blank()
 
-	Log.pr("example object", ExampleObj.new("example val"))
-	Log.pr("with a Vector2i", ExampleObj.new(Vector2i(0, 6)))
-	Log.prn("nested values", example_object)
+	print("example object", ExampleObj.new("example val"))
+	Log.log("example object", ExampleObj.new("example val"))
+	Log.blank()
 
+	print("with a Vector2i", ExampleObj.new(Vector2i(0, 6)))
+	Log.log("with a Vector2i", ExampleObj.new(Vector2i(0, 6)))
+	Log.blank()
+
+	print("nested values", example_object)
+	Log.log("nested values", example_object)
+
+
+## Showcase any known bugs for the running version of Godot.
 func showcase_known_bugs() -> void:
-	print_header("Known Bugs")
 	var version: Dictionary = Engine.get_version_info()
 	if version.major == 4 and version.minor == 4 and version.patch == 1:
 		print_rich_debugging()
 
+
+## Godot 4.4.1 has a [code][[/code] parsing bug - already fixed by Godot 4.5.
+## [br][br]
+## This method has a bunch of test prints reproducing the issue.
 func print_rich_debugging() -> void:
-	# Godot 4.4.1 has a `[` parsing bug - already fixed by Godot 4.5
-	# here's a bunch of test prints reproducing the issue
-	print_header("[ parsing in Godot 4.4.1")
+	print_header("Known Bug: [ parsing in Godot 4.4.1")
 	print_rich("[color=red][[/color]")
 	print_rich("[lb] hi [rb]")
 	print_rich("[color=red][[/color] [color=blue]1, 2[/color] [color=green]][/color]")
@@ -181,3 +312,18 @@ func print_rich_debugging() -> void:
 	print_rich("[color=red]\\[[/color] [color=blue]1, 2[/color] [color=green]][/color]")
 	print_rich("[ [color=blue]1, 2[/color] [color=green]][/color]")
 	print_rich("[color=red]'['[/color] [color=blue]1, 2[/color] [color=green]][/color]")
+
+
+## A simple object used to showcase the [code]to_pretty()[/code] implementation
+## on a custom object.
+class ExampleObj:
+	var val: Variant
+
+	func _init(v: Variant) -> void:
+		val = v
+
+	func to_pretty() -> Variant:
+		return {
+			"val": val,
+			"id": get_instance_id()
+		}

--- a/src/ExampleScene.tscn
+++ b/src/ExampleScene.tscn
@@ -145,6 +145,36 @@ vertical_alignment = 1
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 8
+button_pressed = true
+
+[node name="PanelContainerPrettyColorsChoice" type="PanelContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="MarginContainer" type="MarginContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerPrettyColorsChoice"]
+layout_mode = 2
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 5
+theme_override_constants/margin_bottom = 5
+
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerPrettyColorsChoice/MarginContainer"]
+layout_mode = 2
+
+[node name="RichTextLabel" type="RichTextLabel" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerPrettyColorsChoice/MarginContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+bbcode_enabled = true
+text = "[code]Log.to_pretty()[/code] Color"
+fit_content = true
+scroll_active = false
+autowrap_mode = 0
+vertical_alignment = 1
+
+[node name="ColorPickerButton" type="ColorPickerButton" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerPrettyColorsChoice/MarginContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
 
 [node name="PanelContainerPrettyColors" type="PanelContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions"]
 layout_mode = 2
@@ -173,6 +203,7 @@ vertical_alignment = 1
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 8
+button_pressed = true
 
 [node name="PanelContainerNewlines" type="PanelContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions"]
 layout_mode = 2
@@ -232,6 +263,7 @@ layout_mode = 2
 size_flags_horizontal = 8
 min_value = -1.0
 max_value = 10.0
+value = -1.0
 rounded = true
 allow_greater = true
 allow_lesser = true
@@ -263,6 +295,7 @@ vertical_alignment = 1
 [node name="OptionButtonLogLevel" type="OptionButton" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerLogLevel/MarginContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
+selected = 1
 item_count = 4
 popup/item_0/text = "DEBUG"
 popup/item_0/id = 0
@@ -300,6 +333,7 @@ vertical_alignment = 1
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 8
+button_pressed = true
 
 [connection signal="pressed" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases/ButtonRunShowcases" to="." method="run_showcases"]
 [connection signal="pressed" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases/ButtonRunEasyNewlinesShowcase" to="." method="showcase_easy_newlines"]
@@ -313,6 +347,7 @@ size_flags_horizontal = 8
 [connection signal="pressed" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases/ButtonRunObjectsShowcase" to="." method="showcase_objects"]
 [connection signal="pressed" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases/ButtonRunKnownBugsShowcase" to="." method="showcase_known_bugs"]
 [connection signal="toggled" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerColors/MarginContainer/HBoxContainer/CheckButtonColors" to="." method="set_enable_colors"]
+[connection signal="color_changed" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerPrettyColorsChoice/MarginContainer/HBoxContainer/ColorPickerButton" to="." method="set_custom_color"]
 [connection signal="toggled" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerPrettyColors/MarginContainer/HBoxContainer/CheckButtonPrettyColors" to="." method="set_pretty_colors"]
 [connection signal="toggled" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerNewlines/MarginContainer/HBoxContainer/CheckButtonNewlines" to="." method="set_enable_newlines"]
 [connection signal="value_changed" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerNewlineMaxDepth/MarginContainer/HBoxContainer/SpinBoxNewlineMaxDepth" to="." method="set_newline_max_depth"]

--- a/src/ExampleScene.tscn
+++ b/src/ExampleScene.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=6 format=3 uid="uid://dv5fj7cdea0sh"]
+[gd_scene load_steps=8 format=3 uid="uid://dv5fj7cdea0sh"]
 
 [ext_resource type="Script" uid="uid://cq36gpa2xrlav" path="res://src/ExampleScene.gd" id="1_rghsl"]
 [ext_resource type="Script" uid="uid://bb583pa256cbc" path="res://src/SomeResource.gd" id="2_unowp"]
+[ext_resource type="Theme" uid="uid://o0twyvebgm22" path="res://src/theme_example_scene.tres" id="3_fuo7i"]
 
 [sub_resource type="Resource" id="Resource_d4rid"]
 script = ExtResource("2_unowp")
@@ -18,9 +19,302 @@ script = ExtResource("2_unowp")
 name = "wind bot"
 element = 3
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_87w40"]
+
 [node name="ExampleScene" type="CanvasLayer"]
+follow_viewport_enabled = true
 script = ExtResource("1_rghsl")
 some_custom_types = Array[ExtResource("2_unowp")]([SubResource("Resource_d4rid"), SubResource("Resource_hbyy1"), SubResource("Resource_6lcg3")])
 
 [node name="SomeNode" type="Node" parent="."]
 unique_name_in_owner = true
+
+[node name="PanelContainer" type="PanelContainer" parent="."]
+offset_right = 1280.0
+offset_bottom = 720.0
+theme = ExtResource("3_fuo7i")
+theme_override_styles/panel = SubResource("StyleBoxFlat_87w40")
+
+[node name="MarginContainer" type="MarginContainer" parent="PanelContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 20
+theme_override_constants/margin_top = 20
+theme_override_constants/margin_right = 20
+theme_override_constants/margin_bottom = 20
+
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/MarginContainer"]
+layout_mode = 2
+alignment = 1
+
+[node name="MarginContainerShowcases" type="MarginContainer" parent="PanelContainer/MarginContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="VBoxContainerShowcases" type="VBoxContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases"]
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="ButtonRunShowcases" type="Button" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases"]
+clip_contents = true
+layout_mode = 2
+text = "Run All Showcases"
+
+[node name="ButtonRunEasyNewlinesShowcase" type="Button" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases"]
+clip_contents = true
+layout_mode = 2
+text = "Run Easy Newlines Showcase"
+
+[node name="ButtonRunLogLevelsShowcase" type="Button" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases"]
+clip_contents = true
+layout_mode = 2
+text = "Run Log Levels Showcase"
+
+[node name="ButtonRunColorsShowcase" type="Button" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases"]
+clip_contents = true
+layout_mode = 2
+text = "Run Colors Showcase"
+
+[node name="ButtonRunIntsAndFloatsShowcase" type="Button" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases"]
+clip_contents = true
+layout_mode = 2
+text = "Run Ints and Floats Showcase"
+
+[node name="ButtonRunVectorsShowcase" type="Button" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases"]
+clip_contents = true
+layout_mode = 2
+text = "Run Vectors Showcase"
+
+[node name="ButtonRunStringsShowcase" type="Button" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases"]
+clip_contents = true
+layout_mode = 2
+text = "Run Strings Showcase"
+
+[node name="ButtonRunArraysShowcase" type="Button" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases"]
+clip_contents = true
+layout_mode = 2
+text = "Run Arrays Showcase"
+
+[node name="ButtonRunDictionariesShowcase" type="Button" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases"]
+clip_contents = true
+layout_mode = 2
+text = "Run Dictionaries Showcase"
+
+[node name="ButtonRunObjectsShowcase" type="Button" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases"]
+clip_contents = true
+layout_mode = 2
+text = "Run Objects Showcase"
+
+[node name="ButtonRunKnownBugsShowcase" type="Button" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases"]
+clip_contents = true
+layout_mode = 2
+text = "Run Known Bugs Showcase"
+
+[node name="MarginContainerOptions" type="MarginContainer" parent="PanelContainer/MarginContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="VBoxContainerOptions" type="VBoxContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 3
+
+[node name="PanelContainerColors" type="PanelContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="MarginContainer" type="MarginContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerColors"]
+layout_mode = 2
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 5
+theme_override_constants/margin_bottom = 5
+
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerColors/MarginContainer"]
+layout_mode = 2
+
+[node name="RichTextLabel" type="RichTextLabel" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerColors/MarginContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Use Colors"
+fit_content = true
+scroll_active = false
+autowrap_mode = 0
+vertical_alignment = 1
+
+[node name="CheckButtonColors" type="CheckButton" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerColors/MarginContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 8
+
+[node name="PanelContainerPrettyColors" type="PanelContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="MarginContainer" type="MarginContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerPrettyColors"]
+layout_mode = 2
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 5
+theme_override_constants/margin_bottom = 5
+
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerPrettyColors/MarginContainer"]
+layout_mode = 2
+
+[node name="RichTextLabel" type="RichTextLabel" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerPrettyColors/MarginContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Full Color Theme"
+fit_content = true
+scroll_active = false
+autowrap_mode = 0
+vertical_alignment = 1
+
+[node name="CheckButtonPrettyColors" type="CheckButton" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerPrettyColors/MarginContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 8
+
+[node name="PanelContainerNewlines" type="PanelContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="MarginContainer" type="MarginContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerNewlines"]
+layout_mode = 2
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 5
+theme_override_constants/margin_bottom = 5
+
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerNewlines/MarginContainer"]
+layout_mode = 2
+
+[node name="RichTextLabel" type="RichTextLabel" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerNewlines/MarginContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Use Newlines"
+fit_content = true
+scroll_active = false
+autowrap_mode = 0
+vertical_alignment = 1
+
+[node name="CheckButtonNewlines" type="CheckButton" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerNewlines/MarginContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 8
+
+[node name="PanelContainerNewlineMaxDepth" type="PanelContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="MarginContainer" type="MarginContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerNewlineMaxDepth"]
+layout_mode = 2
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 5
+theme_override_constants/margin_bottom = 5
+
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerNewlineMaxDepth/MarginContainer"]
+layout_mode = 2
+
+[node name="RichTextLabel" type="RichTextLabel" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerNewlineMaxDepth/MarginContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Newline Max Depth"
+fit_content = true
+scroll_active = false
+autowrap_mode = 0
+vertical_alignment = 1
+
+[node name="SpinBoxNewlineMaxDepth" type="SpinBox" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerNewlineMaxDepth/MarginContainer/HBoxContainer"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(88, 31)
+layout_mode = 2
+size_flags_horizontal = 8
+min_value = -1.0
+max_value = 10.0
+rounded = true
+allow_greater = true
+allow_lesser = true
+alignment = 2
+
+[node name="PanelContainerLogLevel" type="PanelContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="MarginContainer" type="MarginContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerLogLevel"]
+layout_mode = 2
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 5
+theme_override_constants/margin_bottom = 5
+
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerLogLevel/MarginContainer"]
+layout_mode = 2
+
+[node name="RichTextLabel" type="RichTextLabel" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerLogLevel/MarginContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Log Level"
+fit_content = true
+scroll_active = false
+autowrap_mode = 0
+vertical_alignment = 1
+
+[node name="OptionButtonLogLevel" type="OptionButton" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerLogLevel/MarginContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+item_count = 4
+popup/item_0/text = "DEBUG"
+popup/item_0/id = 0
+popup/item_1/text = "INFO"
+popup/item_1/id = 1
+popup/item_2/text = "WARN"
+popup/item_2/id = 2
+popup/item_3/text = "ERROR"
+popup/item_3/id = 3
+
+[node name="PanelContainerWarnTodo" type="PanelContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="MarginContainer" type="MarginContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerWarnTodo"]
+layout_mode = 2
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 5
+theme_override_constants/margin_bottom = 5
+
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerWarnTodo/MarginContainer"]
+layout_mode = 2
+
+[node name="RichTextLabel" type="RichTextLabel" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerWarnTodo/MarginContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Warn on Todo"
+fit_content = true
+scroll_active = false
+autowrap_mode = 0
+vertical_alignment = 1
+
+[node name="CheckButtonWarnTodo" type="CheckButton" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerWarnTodo/MarginContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 8
+
+[connection signal="pressed" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases/ButtonRunShowcases" to="." method="run_showcases"]
+[connection signal="pressed" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases/ButtonRunEasyNewlinesShowcase" to="." method="showcase_easy_newlines"]
+[connection signal="pressed" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases/ButtonRunLogLevelsShowcase" to="." method="showcase_log_levels"]
+[connection signal="pressed" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases/ButtonRunColorsShowcase" to="." method="showcase_colors"]
+[connection signal="pressed" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases/ButtonRunIntsAndFloatsShowcase" to="." method="showcase_ints_and_floats"]
+[connection signal="pressed" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases/ButtonRunVectorsShowcase" to="." method="showcase_vectors"]
+[connection signal="pressed" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases/ButtonRunStringsShowcase" to="." method="showcase_strings"]
+[connection signal="pressed" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases/ButtonRunArraysShowcase" to="." method="showcase_arrays"]
+[connection signal="pressed" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases/ButtonRunDictionariesShowcase" to="." method="showcase_dictionaries"]
+[connection signal="pressed" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases/ButtonRunObjectsShowcase" to="." method="showcase_objects"]
+[connection signal="pressed" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases/ButtonRunKnownBugsShowcase" to="." method="showcase_known_bugs"]
+[connection signal="toggled" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerColors/MarginContainer/HBoxContainer/CheckButtonColors" to="." method="set_enable_colors"]
+[connection signal="toggled" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerPrettyColors/MarginContainer/HBoxContainer/CheckButtonPrettyColors" to="." method="set_pretty_colors"]
+[connection signal="toggled" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerNewlines/MarginContainer/HBoxContainer/CheckButtonNewlines" to="." method="set_enable_newlines"]
+[connection signal="value_changed" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerNewlineMaxDepth/MarginContainer/HBoxContainer/SpinBoxNewlineMaxDepth" to="." method="set_newline_max_depth"]
+[connection signal="item_selected" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerLogLevel/MarginContainer/HBoxContainer/OptionButtonLogLevel" to="." method="set_log_level"]
+[connection signal="toggled" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerWarnTodo/MarginContainer/HBoxContainer/CheckButtonWarnTodo" to="." method="set_warn_todo"]

--- a/src/theme_example_scene.tres
+++ b/src/theme_example_scene.tres
@@ -1,0 +1,6 @@
+[gd_resource type="Theme" format=3 uid="uid://o0twyvebgm22"]
+
+[resource]
+default_font_size = 32
+HBoxContainer/constants/separation = 25
+VBoxContainer/constants/separation = 10

--- a/src/theme_example_scene.tres
+++ b/src/theme_example_scene.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" format=3 uid="uid://o0twyvebgm22"]
+[gd_resource type="Theme" load_steps=0 format=3 uid="uid://o0twyvebgm22"]
 
 [resource]
 default_font_size = 32


### PR DESCRIPTION
## Synopsis

This PR cleans up and documents `ExampleScene.gd`.  It also adds a GUI to `ExampleScene` for some interactivity when looking at Log.gd's features.

<img width="752" height="500" alt="Screenshot 2025-08-31 at 11 41 09 AM" src="https://github.com/user-attachments/assets/52fe65ae-b904-4660-af13-2e924875ba69" />



## Context

The example scene deserves some cleanup, especially if it's intended to showcase what Log.gd can do.

This PR is just a first pass at preparing ExampleScene as a gold-standard of sorts for using Log.gd in a project.


## Changes

Some light documentation has been added to `ExampleScene.gd`.

Old commented code has been removed from `ExampleScene.gd`.

Cleanup and restructuring of `ExampleScene.gd` to more closely follow the [GDScript Style Guide](https://docs.godotengine.org/en/4.4/tutorials/scripting/gdscript/gdscript_styleguide.html).

After some cleanup and restructuring, the goofy sleep pattern that was implemented in PR #8 was removed.

A simple GUI has been added to `ExampleScene` to help folks explore Log.gd's features.  The GUI has buttons for running each showcase and toggles for most of Log.gd's features that can be changed via code.

The viewport has been set to `1280` by `720`, up from the default `1152` by `648`, to allow for easier editing of the new GUI.

No additional tests have been added.


## Other Changes

`Log.blank()` has been added to help ensure that showcase output is easily parsable by humans.  It's just a wrapper for an empty `print()` statement at the moment.


## Author's Notes

This PR is squarely in the realm of opinion, but felt like a step in the right direction for this repo.

I'm toying with the idea of `Log.blank()` being toggle-able, so things can be easy-to-read when developing but logs can be more concise when needed.
