### PR TITLE
Optionally prepend timestamps

### DIFF
--- a/addons/log/log.gd
+++ b/addons/log/log.gd
@@ -574,7 +574,7 @@ static func to_printable(msgs: Array, opts: Dictionary = {}) -> String:
 	var pretty: bool = opts.get("pretty", true)
 	var m: String = ""
 	if get_show_timestamps():
-		m = "%s " % Log.timestamp()
+		m = "[%s]" % Log.timestamp()
 	if len(stack) > 0:
 		var prefix: String = Log.log_prefix(stack)
 		var prefix_type: String

--- a/docs/asset_page_content.md
+++ b/docs/asset_page_content.md
@@ -78,6 +78,12 @@ matching logger functions for ease of use: `Log.debug()`, `Log.info()`, `Log.war
 `Log.todo()` is treated as a `WARN`-level log by default, but can be changed to
 an `INFO`-level log in Project Settings or via `Log.disable_warn_todo()`.
 
+### Optionally Customizable Timestamps!
+
+Log.gd can prepend timestamps to log lines if needed.
+
+The timestamp options available are a Unix timestamp, the ticks in microseconds or nanoseconds, and human readable in 12 or 24 hour time.
+
 ## Public API
 
 ### Print functions
@@ -126,6 +132,10 @@ A few functions I use to tweak things at run time (e.g. when running tests).
 - `Log.set_log_level()`
 - `Log.disable_warn_todo()`
 - `Log.enable_warn_todo()`
+- `Log.show_timestamps()`
+- `Log.hide_timestamps()`
+- `Log.use_timestamp_type(timestamp_type: Log.TimestampTypes)`
+- `Log.use_timestamp_format(timestamp_format: String)`
 
 ### Type Handlers
 
@@ -136,6 +146,16 @@ You can 'register' handlers for built-in classes with the below functions.
 - `register_type_overwrites(overwrites: Dictionary)`
   - Overwrites is a dictionary like `{obj.get_class(): handler_func}`
 - `clear_type_overwrites()`
+
+### Timestamp Format
+
+The default timestamp format is `{hour}:{minute}:{second}`.  The supported
+fields are `year`, `month`, `day`, `weekday`, `hour`, `minute`, `second`,
+`meridiem` and `dst`.`
+
+Both `minute` and `second` have preceeding zeroes for both 12- and 24-hour time.
+`hour` only has a preceeding zero when using 24-hour time.  Both `month` and
+`day` also have preceeding zeroes for both 12- and 24-hour time.
 
 ## Settings
 
@@ -165,4 +185,12 @@ Settings instead of Project-wide ones. I'll be moving things around soon!
 - `warn_todo` (`true`)
   - Setting true causes `Log.todo()` to be treated as a `WARN`-level log, false
   and it gets treated as an `INFO`-level log.
+- `show_timestamps` (`false`)
+  - Setting to `true` prepends timestamps for log lines.
+- `timestamp_type` (`HUMAN_12HR`)
+  - Select the type of timestamp printed in the logs.  Options are `UNIX`,
+  `TICKS_MSEC`, `TICKS_USEC`, `HUMAN_12HR`, and `HUMAN_24HR`.
+- `human_readable_timestamp_format` (`{hour}:{minute}:{second}`)
+  - Custom format string for human-readable timestamps.  `meridiem` is only
+  available when using 12-hour time.
 

--- a/docs/homepage.md
+++ b/docs/homepage.md
@@ -150,6 +150,12 @@ matching logger functions for ease of use: `Log.debug()`, `Log.info()`, `Log.war
 `Log.todo()` is treated as a `WARN`-level log by default, but can be changed to
 an `INFO`-level log in Project Settings or via `Log.disable_warn_todo()`.
 
+### Optionally Customizable Timestamps!
+
+Log.gd can prepend timestamps to log lines if needed.
+
+The timestamp options available are a Unix timestamp, the ticks in microseconds or nanoseconds, and human readable in 12 or 24 hour time.
+
 
 ## Public API
 
@@ -199,6 +205,10 @@ A few functions I use to tweak things at run time (e.g. when running tests).
 - `Log.set_log_level()`
 - `Log.disable_warn_todo()`
 - `Log.enable_warn_todo()`
+- `Log.show_timestamps()`
+- `Log.hide_timestamps()`
+- `Log.use_timestamp_type(timestamp_type: Log.TimestampTypes)`
+- `Log.use_timestamp_format(timestamp_format: String)`
 
 ### Type Handlers
 
@@ -209,6 +219,16 @@ You can 'register' handlers for built-in classes with the below functions.
 - `register_type_overwrites(overwrites: Dictionary)`
   - Overwrites is a dictionary like `{obj.get_class(): handler_func}`
 - `clear_type_overwrites()`
+
+### Timestamp Format
+
+The default timestamp format is `{hour}:{minute}:{second}`.  The supported
+fields are `year`, `month`, `day`, `weekday`, `hour`, `minute`, `second`,
+`meridiem` and `dst`.`
+
+Both `minute` and `second` have preceeding zeroes for both 12- and 24-hour time.
+`hour` only has a preceeding zero when using 24-hour time.  Both `month` and
+`day` also have preceeding zeroes for both 12- and 24-hour time.
 
 ## Settings
 
@@ -235,6 +255,14 @@ There are a few Log.gd options available in Project Settings.
 - `warn_todo` (`true`)
   - Setting true causes `Log.todo()` to be treated as a warn-level log, false
   and it gets treated as an info-level log.
+- `show_timestamps` (`false`)
+  - Setting to `true` prepends timestamps for log lines.
+- `timestamp_type` (`HUMAN_12HR`)
+  - Select the type of timestamp printed in the logs.  Options are `UNIX`,
+  `TICKS_MSEC`, `TICKS_USEC`, `HUMAN_12HR`, and `HUMAN_24HR`.
+- `human_readable_timestamp_format` (`{hour}:{minute}:{second}`)
+  - Custom format string for human-readable timestamps.  `meridiem` is only
+  available when using 12-hour time.
 
 ## Other Godot Loggers
 

--- a/src/ExampleScene.gd
+++ b/src/ExampleScene.gd
@@ -34,6 +34,9 @@ var example_object: ExampleObj = ExampleObj.new({
 @onready var spin_box_newline_max_depth: SpinBox = %SpinBoxNewlineMaxDepth
 @onready var option_button_log_level: OptionButton = %OptionButtonLogLevel
 @onready var check_button_warn_todo: CheckButton = %CheckButtonWarnTodo
+@onready var check_button_show_timestamps: CheckButton = %CheckButtonShowTimestamps
+@onready var option_button_timestamp_type: OptionButton = %OptionButtonTimestampType
+@onready var line_edit_timestamp_format: LineEdit = %LineEditTimestampFormat
 
 
 func _ready() -> void:
@@ -44,6 +47,9 @@ func _ready() -> void:
 	spin_box_newline_max_depth.set_value_no_signal(Log.get_newline_max_depth())
 	option_button_log_level.select(Log.get_log_level())
 	check_button_warn_todo.set_pressed_no_signal(Log.get_warn_todo())
+	check_button_show_timestamps.set_pressed_no_signal(Log.get_show_timestamps())
+	option_button_timestamp_type.select(Log.get_timestamp_type())
+	line_edit_timestamp_format.text = Log.get_timestamp_format()
 
 
 ## Connected to CheckButtonColors.
@@ -102,6 +108,35 @@ func set_warn_todo(enable: bool) -> void:
 	else:
 		Log.disable_warn_todo()
 		Log.log("Disabled warn todo")
+
+
+## Connected to CheckButtonShowTimestamps.
+func set_show_timestamps(enable: bool) -> void:
+	if enable:
+		Log.show_timestamps()
+		Log.log("Showing timestamps")
+	else:
+		Log.hide_timestamps()
+		Log.log("Hiding timestamps")
+
+
+## Connected to OptionButtonTimestampType.
+func set_timestamp_type(timestamp_type: int) -> void:
+	var timestamp_type_lookup: Array[String] = [
+		"Unix",
+		"Ticks (milliseconds)",
+		"Ticks (microseconds)",
+		"Human-readable 12-hour",
+		"Human-readable 24-hour",
+	]
+	Log.use_timestamp_type(timestamp_type)
+	Log.log("Timestamp Type: %s" % timestamp_type_lookup[timestamp_type])
+
+
+## Connected to TextEditTimestampFormat.
+func set_timestamp_format(format: String) -> void:
+	Log.use_timestamp_format(format)
+	Log.log("Timestamp format: %s" % format)
 
 
 ## Easily run all Log.gd showcases.

--- a/src/ExampleScene.tscn
+++ b/src/ExampleScene.tscn
@@ -48,7 +48,6 @@ alignment = 1
 
 [node name="MarginContainerShowcases" type="MarginContainer" parent="PanelContainer/MarginContainer/HBoxContainer"]
 layout_mode = 2
-size_flags_horizontal = 3
 
 [node name="VBoxContainerShowcases" type="VBoxContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases"]
 layout_mode = 2
@@ -115,7 +114,6 @@ size_flags_horizontal = 3
 
 [node name="VBoxContainerOptions" type="VBoxContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions"]
 layout_mode = 2
-size_flags_horizontal = 4
 size_flags_vertical = 3
 
 [node name="PanelContainerColors" type="PanelContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions"]
@@ -175,6 +173,7 @@ vertical_alignment = 1
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
+color = Color(0.627451, 0.12549, 0.941176, 1)
 
 [node name="PanelContainerPrettyColors" type="PanelContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions"]
 layout_mode = 2
@@ -335,6 +334,102 @@ layout_mode = 2
 size_flags_horizontal = 8
 button_pressed = true
 
+[node name="PanelContainerShowTimestamps" type="PanelContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="MarginContainer" type="MarginContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerShowTimestamps"]
+layout_mode = 2
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 5
+theme_override_constants/margin_bottom = 5
+
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerShowTimestamps/MarginContainer"]
+layout_mode = 2
+
+[node name="RichTextLabel" type="RichTextLabel" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerShowTimestamps/MarginContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Show Timestamps"
+fit_content = true
+scroll_active = false
+autowrap_mode = 0
+vertical_alignment = 1
+
+[node name="CheckButtonShowTimestamps" type="CheckButton" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerShowTimestamps/MarginContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 8
+button_pressed = true
+
+[node name="PanelContainerTimestampType" type="PanelContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="MarginContainer" type="MarginContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerTimestampType"]
+layout_mode = 2
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 5
+theme_override_constants/margin_bottom = 5
+
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerTimestampType/MarginContainer"]
+layout_mode = 2
+
+[node name="RichTextLabel" type="RichTextLabel" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerTimestampType/MarginContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Timestamp Type"
+fit_content = true
+scroll_active = false
+autowrap_mode = 0
+vertical_alignment = 1
+
+[node name="OptionButtonTimestampType" type="OptionButton" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerTimestampType/MarginContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+selected = 1
+item_count = 5
+popup/item_0/text = "UNIX"
+popup/item_0/id = 0
+popup/item_1/text = "TICKS_MSEC"
+popup/item_1/id = 1
+popup/item_2/text = "TICKS_USEC"
+popup/item_2/id = 2
+popup/item_3/text = "HUMAN_12HR"
+popup/item_3/id = 3
+popup/item_4/text = "HUMAN_24HR"
+popup/item_4/id = 4
+
+[node name="PanelContainerTimestampFormat" type="PanelContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="MarginContainer" type="MarginContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerTimestampFormat"]
+layout_mode = 2
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 5
+theme_override_constants/margin_bottom = 5
+
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerTimestampFormat/MarginContainer"]
+layout_mode = 2
+
+[node name="RichTextLabel" type="RichTextLabel" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerTimestampFormat/MarginContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Timestamp Format"
+fit_content = true
+scroll_active = false
+autowrap_mode = 0
+vertical_alignment = 1
+
+[node name="LineEditTimestampFormat" type="LineEdit" parent="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerTimestampFormat/MarginContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+
 [connection signal="pressed" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases/ButtonRunShowcases" to="." method="run_showcases"]
 [connection signal="pressed" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases/ButtonRunEasyNewlinesShowcase" to="." method="showcase_easy_newlines"]
 [connection signal="pressed" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerShowcases/VBoxContainerShowcases/ButtonRunLogLevelsShowcase" to="." method="showcase_log_levels"]
@@ -353,3 +448,6 @@ button_pressed = true
 [connection signal="value_changed" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerNewlineMaxDepth/MarginContainer/HBoxContainer/SpinBoxNewlineMaxDepth" to="." method="set_newline_max_depth"]
 [connection signal="item_selected" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerLogLevel/MarginContainer/HBoxContainer/OptionButtonLogLevel" to="." method="set_log_level"]
 [connection signal="toggled" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerWarnTodo/MarginContainer/HBoxContainer/CheckButtonWarnTodo" to="." method="set_warn_todo"]
+[connection signal="toggled" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerShowTimestamps/MarginContainer/HBoxContainer/CheckButtonShowTimestamps" to="." method="set_show_timestamps"]
+[connection signal="item_selected" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerTimestampType/MarginContainer/HBoxContainer/OptionButtonTimestampType" to="." method="set_timestamp_type"]
+[connection signal="text_submitted" from="PanelContainer/MarginContainer/HBoxContainer/MarginContainerOptions/VBoxContainerOptions/PanelContainerTimestampFormat/MarginContainer/HBoxContainer/LineEditTimestampFormat" to="." method="set_timestamp_format"]

--- a/test/log_test.gd
+++ b/test/log_test.gd
@@ -407,8 +407,8 @@ func test_show_timestamp() -> void:
 	Log.to_printable(["test"])
 	assert_str(Log.to_printable(["test"])) \
 			.ends_with("test") \
-			.has_length(12, Comparator.GREATER_EQUAL) \
-			.has_length(13, Comparator.LESS_EQUAL)
+			.has_length(13, Comparator.GREATER_EQUAL) \
+			.has_length(14, Comparator.LESS_EQUAL)
 
 	Log.hide_timestamps()
 	assert_str(Log.to_printable(["test"])).is_equal("test")
@@ -416,8 +416,8 @@ func test_show_timestamp() -> void:
 	Log.show_timestamps()
 	assert_str(Log.to_printable(["test"])) \
 			.ends_with("test") \
-			.has_length(12, Comparator.GREATER_EQUAL) \
-			.has_length(13, Comparator.LESS_EQUAL)
+			.has_length(13, Comparator.GREATER_EQUAL) \
+			.has_length(14, Comparator.LESS_EQUAL)
 
 func test_timestamp_human_readable() -> void:
 	Log.disable_colors()
@@ -428,12 +428,12 @@ func test_timestamp_human_readable() -> void:
 	Log.to_printable(["test"])
 	assert_str(Log.to_printable(["test"])) \
 			.ends_with("test") \
-			.has_length(15, Comparator.GREATER_EQUAL) \
-			.has_length(16, Comparator.LESS_EQUAL)
+			.has_length(16, Comparator.GREATER_EQUAL) \
+			.has_length(17, Comparator.LESS_EQUAL)
 
 	Log.use_timestamp_type(Log.TimestampTypes.HUMAN_24HR)
 	Log.use_timestamp_format(Log.CONFIG_DEFAULTS[Log.KEY_HUMAN_READABLE_TIMESTAMP_FORMAT])
 	Log.to_printable(["test"])
 	assert_str(Log.to_printable(["test"])) \
 			.ends_with("test") \
-			.has_length(13, Comparator.EQUAL)
+			.has_length(14, Comparator.EQUAL)

--- a/test/log_test.gd
+++ b/test/log_test.gd
@@ -345,6 +345,8 @@ func test_disable_colors_via_config() -> void:
 	Log.enable_colors()
 	assert_str(Log.to_pretty(1)).is_equal("[color=green]1[/color]")
 
+## newlines ##########################################
+
 func test_disable_newline_to_pretty() -> void:
 	const INPUT: Dictionary = {"one": 1, "two": 2}
 	const OUTPUT_WITH_NEWLINES: String = "{ \n\t\"one\": 1, \n\t\"two\": 2 }"
@@ -352,7 +354,6 @@ func test_disable_newline_to_pretty() -> void:
 
 	assert_str(Log.to_pretty(INPUT, {disable_colors=true, newlines=true})).is_equal(OUTPUT_WITH_NEWLINES)
 	assert_str(Log.to_pretty(INPUT, {disable_colors=true, newlines=false})).is_equal(OUTPUT_WITHOUT_NEWLINES)
-
 
 func test_disable_newline_via_config() -> void:
 	const INPUT: Dictionary = {"one": 1, "two": 2}
@@ -379,7 +380,6 @@ func test_newline_max_depth_to_pretty() -> void:
 	assert_str(Log.to_pretty(INPUT, {disable_colors=true, newlines=true, newline_max_depth=1})).is_equal(OUTPUT_DEPTH_1)
 	assert_str(Log.to_pretty(INPUT, {disable_colors=true, newlines=true, newline_max_depth=2})).is_equal(OUTPUT_DEPTH_2)
 
-
 func test_newline_max_depth_via_config() -> void:
 	const INPUT: Dictionary = {"one": 1, "two": {"three": 3, "four": 4}}
 	const OUTPUT_DEPTH_0: String = "{ \"one\": 1, \"two\": { \"three\": 3, \"four\": 4 } }"
@@ -397,3 +397,43 @@ func test_newline_max_depth_via_config() -> void:
 
 	Log.set_newline_max_depth(2)
 	assert_str(Log.to_pretty(INPUT)).is_equal(OUTPUT_DEPTH_2)
+
+## timestamps ##########################################
+
+func test_show_timestamp() -> void:
+	Log.disable_colors()
+
+	Log.show_timestamps()
+	Log.to_printable(["test"])
+	assert_str(Log.to_printable(["test"])) \
+			.ends_with("test") \
+			.has_length(12, Comparator.GREATER_EQUAL) \
+			.has_length(13, Comparator.LESS_EQUAL)
+
+	Log.hide_timestamps()
+	assert_str(Log.to_printable(["test"])).is_equal("test")
+
+	Log.show_timestamps()
+	assert_str(Log.to_printable(["test"])) \
+			.ends_with("test") \
+			.has_length(12, Comparator.GREATER_EQUAL) \
+			.has_length(13, Comparator.LESS_EQUAL)
+
+func test_timestamp_human_readable() -> void:
+	Log.disable_colors()
+	Log.show_timestamps()
+
+	Log.use_timestamp_type(Log.TimestampTypes.HUMAN_12HR)
+	Log.use_timestamp_format("{hour}:{minute}:{second} {meridiem}")
+	Log.to_printable(["test"])
+	assert_str(Log.to_printable(["test"])) \
+			.ends_with("test") \
+			.has_length(15, Comparator.GREATER_EQUAL) \
+			.has_length(16, Comparator.LESS_EQUAL)
+
+	Log.use_timestamp_type(Log.TimestampTypes.HUMAN_24HR)
+	Log.use_timestamp_format(Log.CONFIG_DEFAULTS[Log.KEY_HUMAN_READABLE_TIMESTAMP_FORMAT])
+	Log.to_printable(["test"])
+	assert_str(Log.to_printable(["test"])) \
+			.ends_with("test") \
+			.has_length(13, Comparator.EQUAL)


### PR DESCRIPTION
⚠️ Opinionated PR ⚠️

## Synopsis

Optionally prepend timestamps to log output.


## Changes

Settings have been added to show/hide timestamps, set the type of timestamp used, and the format of human-readable timestamps.

Timestamps use Godot's `.format()` method under the hood to allow for optional fields.  The default format is `{hour}:{minute}:{second}`.

The example scene has been updated to help showcase timestamp options.

Tests have been added to ensure timestamps show/hide appropriately and to ensure human-readable formats work as-expected.


## Author's Notes

I've considered using something like [.NET's approach](https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings) for differing format values.

Not sure if the proverbial juice is worth the squeeze there, but if folks are interested I can make that change.