### PR TITLE
Fix: Workaround fix for issue #[#18] First message ignores log level

### DIFF
--- a/addons/log/log.gd
+++ b/addons/log/log.gd
@@ -170,6 +170,8 @@ static func get_newline_max_depth() -> int:
 	return Log.config.get(KEY_NEWLINE_MAX_DEPTH, CONFIG_DEFAULTS[KEY_NEWLINE_MAX_DEPTH])
 
 static func get_log_level() -> int:
+	if not Log.is_config_setup:
+		rebuild_config()
 	return Log.config.get(KEY_LOG_LEVEL, CONFIG_DEFAULTS[KEY_LOG_LEVEL])
 
 static func get_warn_todo() -> int:


### PR DESCRIPTION
It could be that in the plugin.gd in _enter_tree() the lines

```
Log.setup_settings()
Log.rebuild_config()

```
not setting the var Log.is_config_setup correct, i don't know why
all my trial didn't work

So i have added this lines

```
 if not Log.is_config_setup:
     rebuild_config()
```

to the func `get_log_level() `